### PR TITLE
resolved redirects don't need to be a document

### DIFF
--- a/build/flaws.js
+++ b/build/flaws.js
@@ -98,20 +98,7 @@ function injectFlaws(doc, $, options, { rawContent }) {
           // Before we give up, check if it's a redirect
           const resolved = Redirect.resolve(hrefNormalized);
           if (resolved) {
-            // Just because it's a redirect doesn't mean it ends up
-            // on a page we have.
-            // For example, there might be a redirect but where it
-            // goes to is not in this.allTitles.
-            // This can happen if it's a "fundamental redirect" for example.
-            const finalDocument = Document.findByURL(resolved);
-            addBrokenLink(
-              a,
-              checked.get(href),
-              href,
-              finalDocument
-                ? finalDocument.url + absoluteURL.search + absoluteURL.hash
-                : null
-            );
+            addBrokenLink(a, checked.get(href), href, resolved);
           } else {
             addBrokenLink(a, href);
           }

--- a/build/flaws.js
+++ b/build/flaws.js
@@ -97,10 +97,15 @@ function injectFlaws(doc, $, options, { rawContent }) {
         if (!found) {
           // Before we give up, check if it's a redirect
           const resolved = Redirect.resolve(hrefNormalized);
-          if (resolved) {
-            addBrokenLink(a, checked.get(href), href, resolved);
+          if (resolved !== hrefNormalized) {
+            addBrokenLink(
+              a,
+              checked.get(href),
+              href,
+              resolved + absoluteURL.search + absoluteURL.hash
+            );
           } else {
-            addBrokenLink(a, href);
+            addBrokenLink(a, checked.get(href), href);
           }
         } else {
           // But does it have the correct case?!


### PR DESCRIPTION
You can see the effect of this here: http://localhost:3000/en-US/docs/Web/API/HTMLInputElement#_flaws

Before:
<img width="829" alt="Screen Shot 2020-10-08 at 4 03 26 PM" src="https://user-images.githubusercontent.com/26739/95509759-e78b5a00-0982-11eb-84cb-75cbcb9a8b25.png">

After:
<img width="851" alt="Screen Shot 2020-10-08 at 4 05 54 PM" src="https://user-images.githubusercontent.com/26739/95509771-ed813b00-0982-11eb-9572-c3d058718b22.png">

It basically is less picky. Now, if a hyperlink points to something that the fundamental redirects resolve, it's considered better than nothing. Does that make sense?

