### PR TITLE
updates to fundamental-redirects-lambda

### DIFF
--- a/deployer/aws-lambda/content-origin-request/yarn.lock
+++ b/deployer/aws-lambda/content-origin-request/yarn.lock
@@ -5,6 +5,9 @@
 "@mdn/fundamental-redirects@file:../../../libs/fundamental-redirects":
   version "0.0.1"
 
+"@mdn/global-constants@file:../../../libs/global-constants":
+  version "0.0.1"
+
 accept-language-parser@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/accept-language-parser/-/accept-language-parser-1.5.0.tgz#8877c54040a8dcb59e0a07d9c1fde42298334791"


### PR DESCRIPTION
@fiji-flo I don't normally submit PR's against PR's, so sorry about this, but it was again easier because I had to try things anyway while debugging ths Lambda function in AWS. This really is just two essential changes:
- `request.headers["accept-language"]`, if present, will always be a single item array in AWS Lambda@Edge functions, so just had to change that to grab the first item if present.
- typo where `VALID_LOCALES_LIST` was wrapped in an array

and one optional change. The change to the redirect function was simply something I tossed in, since it felt cleaner, i.e. played better with your fundamental redirects. I should have done it that way from the start.